### PR TITLE
Allow EnsembleCalculator to store more properties

### DIFF
--- a/cascade/auditor.py
+++ b/cascade/auditor.py
@@ -62,7 +62,7 @@ class ForceThresholdAuditor(BaseAuditor):
               n_audits: int,
               sort_audits: bool = False) -> tuple[float, list[int]]:
 
-        force_preds = np.asarray([a.info['forces_ens'] for a in atoms])
+        force_preds = np.asarray([a.calc.results['forces_ens'] for a in atoms])
 
         # flatten the predictions we have one dim for the ensemble and one for the rest
         # last dim is spatial (3)

--- a/cascade/calculator.py
+++ b/cascade/calculator.py
@@ -1,10 +1,11 @@
 """Utilities for employing ASE calculators"""
+from typing import List
 from pathlib import Path
 from string import Template
 from hashlib import sha256
 import numpy as np
 
-from ase.calculators.calculator import Calculator, all_changes
+from ase.calculators.calculator import Calculator, all_changes, all_properties
 from ase.calculators.cp2k import CP2K
 from ase import units, Atoms
 
@@ -110,13 +111,13 @@ def make_calculator(
 class EnsembleCalculator(Calculator):
     """A single calculator which combines the results of many
 
-    The when run on atoms, ensemble average of energy and forces are stored in atoms.calc.results
-    Additionally, the forces from each ensemble member are stored in atoms.info['forces_ens']
+    Stores the mean of all calculators as the standard property names,
+    and stores the values for each calculator in the :attr:`results`
+    as the name of the property with "_ens" appended (e.g., "forces_ens")
 
     Args:
         calculators: the calculators to ensemble over
     """
-    implemented_properties = ['energy', 'forces']
 
     def __init__(self,
                  calculators: list[Calculator],
@@ -125,32 +126,34 @@ class EnsembleCalculator(Calculator):
         Calculator.__init__(self, **kwargs)
         self.calculators = calculators
         self.num_calculators = len(calculators)
-        self.count = 0
+
+    @property
+    def implemented_properties(self) -> List[str]:
+        joint = set(self.calculators[0].implemented_properties)
+        for calc in self.calculators[1:]:
+            joint.intersection_update(calc.implemented_properties)
+
+        return list(joint)
 
     def calculate(self,
                   atoms: Atoms = None,
-                  properties=('energy', 'forces'),
+                  properties=all_properties,
                   system_changes=all_changes):
-        # create arrays for energy and forces
-        results = {
-            'energy': np.zeros(self.num_calculators).copy(),
-            'forces': np.zeros((self.num_calculators, len(atoms), 3)).copy()
-        }
 
-        # compute and store energy and forces for each calculator
-        for i, calc in enumerate(self.calculators):
-            calc.calculate(atoms,
-                           properties=properties,
-                           system_changes=system_changes)
+        # Run each of the subcalculators
+        for calc in self.calculators:
+            calc.calculate(atoms, properties=properties, system_changes=system_changes)
 
-            for k in results.keys():
-                results[k][i] = calc.results[k]
+        # Determine the intersection of the properties computed from all calculators
+        all_results = set(self.calculators[0].results.keys())
+        for calc in self.calculators[1:]:
+            all_results.intersection_update(calc.results.keys())
 
-        # store the ensemble forces in atoms.info
-        atoms.info['forces_ens'] = results['forces'].copy()
+        # Merge their results
+        results = {}
+        for key in all_results:
+            all_results = np.concatenate([np.expand_dims(calc.results[key], axis=0) for calc in self.calculators], axis=0)
+            results[f'{key}_ens'] = all_results
+            results[key] = all_results.mean(axis=0)
 
-        # average over the ensemble dimension for the mean forces
-        for k in 'energy', 'forces':
-            results[k] = results[k].mean(0)
-
-        self.results.update(results)
+        self.results = results

--- a/cascade/utils.py
+++ b/cascade/utils.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import ase
 from ase import Atoms
 from ase.calculators.calculator import Calculator
+from ase.calculators.singlepoint import SinglePointCalculator
 
 
 # Taken from ExaMol
@@ -49,8 +50,12 @@ def canonicalize(atoms: Atoms) -> Atoms:
     Returns:
         Atoms object that has been serialized and deserialized
     """
-    fmt = 'extxyz'  # the ase.io format to write to and read from
-    return read_from_string(write_to_string(atoms, fmt), fmt)
+    # TODO (wardlt): Make it so the single-point calculator can hold unknown properties? (see discussion https://gitlab.com/ase/ase/-/issues/782)
+    if atoms.calc is not None:
+        old_calc = atoms.calc
+        atoms.calc = SinglePointCalculator(atoms)
+        atoms.calc.results = old_calc.results.copy()
+    return atoms
 
 
 def apply_calculator(

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,8 +1,9 @@
+from ase.calculators.lj import LennardJones
 from ase.build import molecule
 from ase import Atoms
 from pytest import fixture, mark
 
-from cascade.calculator import make_calculator
+from cascade.calculator import make_calculator, EnsembleCalculator
 
 
 @fixture()
@@ -19,3 +20,17 @@ def test_make_calculator(method, example_cell, tmpdir):
     calc = make_calculator(method, directory=tmpdir)
     with calc:
         calc.get_potential_energy(example_cell)
+
+
+def test_ensemble_calculator(example_cell):
+    lj1, lj2 = LennardJones(sigma=1, eps=1), LennardJones(sigma=1, epsilon=1.1)
+    ens = EnsembleCalculator([lj1, lj2])
+    assert set(ens.implemented_properties) == set(lj2.implemented_properties)
+
+    forces = ens.get_forces(example_cell)
+    assert forces.shape == (len(example_cell), 3)
+    assert ens.results['forces_ens'].shape == (2, len(example_cell), 3)
+
+    stress = ens.get_stress(example_cell)
+    assert stress.shape == (6,)
+    assert ens.results['stress_ens'].shape == (2, 6)

--- a/tests/test_ensembling.py
+++ b/tests/test_ensembling.py
@@ -61,7 +61,7 @@ def test_ensemble(trajectories):
     assert np.isclose(f_mean, f_ens).all()
 
     # assert we get the ensemble member forces and they also have the correct values
-    f_ens_members = np.asarray([a.info['forces_ens'] for a in t_ens])
+    f_ens_members = np.asarray([a.calc.results['forces_ens'] for a in t_ens])
     f_ens_lj1 = f_ens_members[:, 0, 0, 0]
     f_ens_lj2 = f_ens_members[:, 1, 0, 0]
     assert np.isclose(f_ens_lj1, f_lj1).all()


### PR DESCRIPTION
Automatically determine the available properties from the sub calculator's results rather than hard-coding to only force and energy.

Also puts all outputs in `results` rather than spreading them out between `info` and `results`.