### PR TITLE
Handle blending of stress calculations

### DIFF
--- a/cascade/learning/chgnet.py
+++ b/cascade/learning/chgnet.py
@@ -56,7 +56,7 @@ class CHGNetInterface(BaseLearnableForcefield[CHGNet]):
                  model_msg: bytes | CHGNet,
                  atoms: list[ase.Atoms],
                  batch_size: int = 64,
-                 device: str = 'cpu') -> (np.ndarray, list[np.ndarray], np.ndarray):
+                 device: str = 'cpu') -> tuple[np.ndarray, list[np.ndarray], np.ndarray]:
         model = self.get_model(model_msg)
         model.to(device)
 

--- a/cascade/learning/torchani/ase.py
+++ b/cascade/learning/torchani/ase.py
@@ -8,7 +8,6 @@
 # TODO (wardlt): TorchANI is in a code freeze as they refactor, so I'm copying my alterations over to here
 #  They are originally from https://github.com/aiqm/torchani/blob/17204c6dccf6210753bc8c0ca4c92278b60719c9/torchani/ase.py
 
-import numpy as np
 import torch
 from ase.calculators.calculator import all_properties
 
@@ -103,8 +102,4 @@ class Calculator(ase.calculators.calculator.Calculator):
         if 'stress' in properties:
             volume = self.atoms.get_volume()
             stress = torch.autograd.grad(energy.squeeze(), scaling)[0] / volume
-            stress = stress.cpu().numpy()
-            # put in voigt form to match ASE defaults
-            stress = np.array([stress[0, 0], stress[1, 1], stress[2, 2],
-                               stress[1, 2], stress[0, 2], stress[0, 1]])
-            self.results['stress'] = stress
+            self.results['stress'] = stress.cpu().numpy()

--- a/cascade/learning/torchani/ase.py
+++ b/cascade/learning/torchani/ase.py
@@ -8,6 +8,7 @@
 # TODO (wardlt): TorchANI is in a code freeze as they refactor, so I'm copying my alterations over to here
 #  They are originally from https://github.com/aiqm/torchani/blob/17204c6dccf6210753bc8c0ca4c92278b60719c9/torchani/ase.py
 
+import numpy as np
 import torch
 from ase.calculators.calculator import all_properties
 
@@ -102,4 +103,8 @@ class Calculator(ase.calculators.calculator.Calculator):
         if 'stress' in properties:
             volume = self.atoms.get_volume()
             stress = torch.autograd.grad(energy.squeeze(), scaling)[0] / volume
-            self.results['stress'] = stress.cpu().numpy()
+            stress = stress.cpu().numpy()
+            # put in voigt form to match ASE defaults
+            stress = np.array([stress[0, 0], stress[1, 1], stress[2, 2],
+                               stress[1, 2], stress[0, 2], stress[0, 1]])
+            self.results['stress'] = stress

--- a/cascade/proxima/__init__.py
+++ b/cascade/proxima/__init__.py
@@ -231,10 +231,9 @@ class SerialLearningCalculator(Calculator):
             results_surrogate = self.surrogate_calc.results
             self.results = {}
             for k in results_surrogate.keys():
-                if k in results_target.keys(): # blend on the intersection of keys
+                if k in results_target.keys():  # blend on the intersection of keys
                     r_target, r_surrogate = results_target[k], results_surrogate[k]
-                    
-                    # handle differences in voigt vs (3,3) stress convention
+                    #  handle differences in voigt vs (3,3) stress convention
                     if k == 'stress' and r_target.shape != r_surrogate.shape:
                         r_target, r_surrogate = map(to_voigt, [r_target, r_surrogate])
                     self.results[k] = self.lambda_target*r_target + (1-self.lambda_target)*r_surrogate

--- a/cascade/proxima/__init__.py
+++ b/cascade/proxima/__init__.py
@@ -13,6 +13,7 @@ from ase.db import connect
 
 from cascade.learning.base import BaseLearnableForcefield
 from cascade.calculator import EnsembleCalculator
+from cascade.utils import to_voigt
 
 logger = logging.getLogger(__name__)
 
@@ -230,8 +231,13 @@ class SerialLearningCalculator(Calculator):
             results_surrogate = self.surrogate_calc.results
             self.results = {}
             for k in results_surrogate.keys():
-                if k in results_target.keys():
-                    self.results[k] = self.lambda_target * results_target[k] + (1-self.lambda_target)*results_surrogate[k]
+                if k in results_target.keys(): # blend on the intersection of keys
+                    r_target, r_surrogate = results_target[k], results_surrogate[k]
+                    
+                    # handle differences in voigt vs (3,3) stress convention
+                    if k == 'stress' and r_target.shape != r_surrogate.shape:
+                        r_target, r_surrogate = map(to_voigt, [r_target, r_surrogate])
+                    self.results[k] = self.lambda_target*r_target + (1-self.lambda_target)*r_surrogate
                 else:
                     # the surrogate may have some extra results which we store
                     self.results[k] = results_surrogate[k]

--- a/cascade/utils.py
+++ b/cascade/utils.py
@@ -80,18 +80,16 @@ def apply_calculator(
 
 
 def to_voigt(stress: np.ndarray) -> np.ndarray:
-    """Converts a (3,3) stress tensor to voigt form
-    
-    Will also return the input stress tensor if it is already in voigt form
-    Args: 
-        stress: a (3,3) stress tensor. Can also be of shape (6,), in shich case
-                this function is a no-op
-    Returns: 
+    """Converts a (3,3) stress tensor to voigt form, or do nothing if its already in this form
+
+    Args:
+        stress: a stess tensor of shape (3,3) or (6,), in which case this function is a no-op
+    Returns:
         stress: a (6,) stress tensor in voigt form
     """
-    if stress.shape == (3,3):
+    if stress.shape == (3, 3):
         stress = np.array([stress[0, 0], stress[1, 1], stress[2, 2],
                            stress[1, 2], stress[0, 2], stress[0, 1]])
-    elif stress.shape != (6,):
+    elif stress.shape != (6, ):
         raise ValueError(f"Stress tensor must either be of shape (3,3) or (6,), got {stress.shape}")
     return stress

--- a/cascade/utils.py
+++ b/cascade/utils.py
@@ -1,6 +1,7 @@
 from io import StringIO
 from copy import deepcopy
 
+import numpy as np
 import ase
 from ase import Atoms
 from ase.calculators.calculator import Calculator
@@ -76,3 +77,21 @@ def apply_calculator(
         atoms.get_forces()
         traj[i] = canonicalize(atoms)
     return traj
+
+
+def to_voigt(stress: np.ndarray) -> np.ndarray:
+    """Converts a (3,3) stress tensor to voigt form
+    
+    Will also return the input stress tensor if it is already in voigt form
+    Args: 
+        stress: a (3,3) stress tensor. Can also be of shape (6,), in shich case
+                this function is a no-op
+    Returns: 
+        stress: a (6,) stress tensor in voigt form
+    """
+    if stress.shape == (3,3):
+        stress = np.array([stress[0, 0], stress[1, 1], stress[2, 2],
+                           stress[1, 2], stress[0, 2], stress[0, 1]])
+    elif stress.shape != (6,):
+        raise ValueError(f"Stress tensor must either be of shape (3,3) or (6,), got {stress.shape}")
+    return stress

--- a/tests/test_proxima.py
+++ b/tests/test_proxima.py
@@ -179,7 +179,7 @@ def test_blending(starting_frame, simple_model, target_calc, tmpdir):
     for i in range(1, n_blending_steps+1):
         new_atoms = starting_frame.copy()
         new_atoms.rattle(0.2, seed=i+100)  # don't reuse above seeds
-        calc.get_forces(new_atoms)
+        calc.get_stress(new_atoms)  # test blending of stresses since this caused errors in the past
         assert calc.used_surrogate
         assert calc.blending_step == i
     assert calc.lambda_target == 0


### PR DESCRIPTION
Adds a `to_voigt` method and associated logic to apply it so that stress tensors from calculators with differing conventions can be blended.