### PR TITLE
Add option to begin training from initial models

### DIFF
--- a/2_proxima/0_run-serial-proxima.py
+++ b/2_proxima/0_run-serial-proxima.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
     group.add_argument('--training-batch-size', type=int, default=32, help='Which device to use for training models')
     group.add_argument('--training-max-size', type=int, default=None, help='Maximum training set size to use when updating models')
     group.add_argument('--training-recency-bias', type=float, default=1., help='Factor by which to favor recent data when reducing training set size')
+    group.add_argument('--training-learning-rate', type=float, default=1e-3, help='Initial learning rate for the optimizer.')
     group.add_argument('--training-device', default='cuda', help='Which device to use for training models')
 
     group = parser.add_argument_group(title='Proxima', description="Settings for learning on the fly")
@@ -167,6 +168,7 @@ if __name__ == "__main__":
             'num_epochs': args.training_epochs,
             'batch_size': args.training_batch_size,
             'reset_weights': args.training_mode == 'reset',
+            'learning_rate': args.training_learning_rate,
             'device': args.training_device},  # Configuration for the training routines
         train_freq=args.retrain_freq,
         train_max_size=args.training_max_size,

--- a/cascade/proxima/__init__.py
+++ b/cascade/proxima/__init__.py
@@ -318,7 +318,7 @@ class SerialLearningCalculator(Calculator):
             'threshold': self.threshold,
             'alpha': self.alpha,
             'blending_step': int(self.blending_step),
-            'error_history': list(self.error_history),
+            'error_history': list(self.error_history) if self.error_history is not None else [],
             'new_points': self.new_points,
             'train_logs': self.train_logs,
             'total_invocations': self.total_invocations,

--- a/tests/test_proxima.py
+++ b/tests/test_proxima.py
@@ -214,3 +214,20 @@ def test_blending(starting_frame, simple_model, target_calc, tmpdir):
         assert not calc.used_surrogate
         assert calc.blending_step == 0
         assert calc.lambda_target == 1
+
+
+def test_train_from_original(starting_frame, simple_proxima, initialized_db):
+    # Set the train_from_original flag
+    simple_proxima.parameters['train_from_original'] = True
+    assert simple_proxima.models is None  # Should start unset
+
+    # Ensure the original models are unchanged
+    orig_models = simple_proxima.parameters['models'].copy()
+    simple_proxima.retrain_surrogate()
+    assert all(x is y for x, y in zip(simple_proxima.parameters['models'], orig_models))
+    assert all(x is not y for x, y in zip(simple_proxima.models, orig_models))
+
+    # Ensure that pickling does not alter the original models
+    state = pkl.loads(pkl.dumps(simple_proxima.get_state()))
+    simple_proxima.set_state(state)
+    assert all(x is y for x, y in zip(simple_proxima.parameters['models'], orig_models))


### PR DESCRIPTION
I'm concerned that we're deviating too far from the original weights of a pre-trained model, so am adding an option where we finetune from the original model before training.

Fixes #50 

To do:
- [x] Add to the proxima test script
- [x] Verify the test script works, comment on effect