### PR TITLE
Bug fix: MACE required results for inference

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,6 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         environment-file: environment.yml
-        mamba-version: "*"
     - name: Install test dependencies
       run: |
         pip install -e .[test,ani,chgnet,mace]

--- a/tests/learning/test_mace.py
+++ b/tests/learning/test_mace.py
@@ -29,6 +29,10 @@ def test_training(example_data, mace, reset_weights):
 
 
 def test_inference(mace, example_data):
+    # Delete any previous results from the example data
+    for atoms in example_data:
+        atoms.calc = None
+
     mi = MACEInterface()
     energy, forces, stresses = mi.evaluate(mace, example_data)
 


### PR DESCRIPTION
Making a data loader requires that computed properties already exist, which is nonsense.