### PR TITLE
Install cp2k via conda-forge

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -43,7 +43,6 @@ jobs:
              echo "$RUNNER_OS not supported"
              exit 1
            fi
-      shell: bash
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,8 +27,18 @@ jobs:
     - name: Add quantum chemistry tools (Linux)
       run: |
            if [ "$RUNNER_OS" == "Linux" ]; then
-             sudo apt update
-             sudo apt install -y cp2k
+             # CP2K package has disappeared as of 21Jan25
+             # sudo apt update
+             # sudo apt install -y cp2k lammps
+
+             # Link the cp2k.ssmp executable to the cp2k_shell needed for ASE
+             mkdir -p bin
+             cp2k_path=`which cp2k.ssmp`
+             export CP2K_DATA_DIR=`which cp2k.ssmp | xargs dirname`/../share/cp2k/data/
+             echo -e "#!/bin/bash\nCP2K_DATA_DIR=$CP2K_DATA_DIR `which cp2k.ssmp` --shell \$@" > bin/cp2k_shell
+             chmod u+x bin/cp2k_shell
+             cat `which cp2k_shell`
+             echo -n | ./bin/cp2k_shell --version
            else
              echo "$RUNNER_OS not supported"
              exit 1
@@ -39,7 +49,9 @@ jobs:
         pip install flake8
         flake8 cascade tests
     - name: Test with pytest
-      run: pytest --cov=cascade --forked --timeout=300 tests
+      run: |
+        export PATH=$PATH:`realpath ./bin`  # Ensure CP2K is visible
+        pytest --cov=cascade --forked --timeout=300 tests
     - name: Coveralls
       run: |
         pip install coveralls

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 
   # Computational chemistry
   - packmol
+  - cp2k
 
   # For nersc's jupyterlab
   - ipykernel


### PR DESCRIPTION
Also requires some trickery in mapping the cp2k.psmp executable provided with conda-forge to the cp2k_shell executable required by ASE.